### PR TITLE
:sparkles: feat(components): add average point and circle

### DIFF
--- a/ExtremeMemory/src/components/pinchable-dart.tsx
+++ b/ExtremeMemory/src/components/pinchable-dart.tsx
@@ -603,7 +603,6 @@ export default function PinchableDart({
     e.preventDefault();
 
     if (touchTimerRef.current !== null && !hasMoved) {
-      console.log(Date.now());
       const canvas = canvasRef.current;
       if (!canvas || !contextRef.current) return;
 


### PR DESCRIPTION
## Summary by Sourcery

Add visual average and circle features, mouse interactions, and configurable styling and scale limits to the PinchableDart component.

New Features:
- Add average point indicator and bounding circle around points in the pinchable dart component
- Enable mouse support for adding and dragging points via click and long-press

Enhancements:
- Introduce props for customizing dragging point color, average point color, circle stroke color, and configurable min/max canvas scale
- Replace map with forEach in drawing loops and fix coordinate calculation for dragging points