### PR TITLE
:bug: fix(components): fix the max offset of dart center for mobile

### DIFF
--- a/ExtremeMemory/src/components/pinchable-dart.tsx
+++ b/ExtremeMemory/src/components/pinchable-dart.tsx
@@ -57,6 +57,8 @@ interface PinchableDartProps {
   minScale?: number;
   /** The max scale of canvas */
   maxScale?: number;
+  /** The max offset of dart center */
+  maxOffset?: number;
 }
 
 function throttle(callbackFn: Function, delay: number) {
@@ -92,6 +94,7 @@ export default function PinchableDart({
   pointRadius = 5,
   minScale = 0.5,
   maxScale = 5,
+  maxOffset = 400,
 }: PinchableDartProps) {
   const canvasRef = useRef<Optional<HTMLCanvasElement>>(null);
   const contextRef = useRef<Optional<CanvasRenderingContext2D>>(null);
@@ -445,10 +448,15 @@ export default function PinchableDart({
         (touch1.y + touch2.y) / 2 -
         (initialPinchPair[0].y + initialPinchPair[1].y) / 2;
 
-      setCenter({
-        x: center.x + absoluteOffsetX * scale,
-        y: center.y + absoluteOffsetY * scale,
-      });
+      if (
+        Math.abs(absoluteOffsetX * scale) <= maxOffset &&
+        Math.abs(absoluteOffsetY * scale) <= maxOffset
+      ) {
+        setCenter({
+          x: center.x + absoluteOffsetX * scale,
+          y: center.y + absoluteOffsetY * scale,
+        });
+      }
 
       // center is the absolute coordinate.
     } else if (e.touches.length === 1) {


### PR DESCRIPTION
## Summary by Sourcery

Add a maximum offset constraint to the PinchableDart component to prevent the dart from panning too far on mobile.

Bug Fixes:
- Introduce a new maxOffset prop (defaulting to 400) to limit the maximum pan distance of the dart center
- Only update the dart center when the calculated offset is within the maxOffset range