### PR TITLE
:bug: fix(mobile): fix the touch event and pinch gesture problem on mobile end

### DIFF
--- a/ExtremeMemory/src/components/pinchable-dart.tsx
+++ b/ExtremeMemory/src/components/pinchable-dart.tsx
@@ -94,7 +94,7 @@ export default function PinchableDart({
   pointRadius = 5,
   minScale = 0.5,
   maxScale = 5,
-  maxOffset = 400,
+  maxOffset = 40,
 }: PinchableDartProps) {
   const canvasRef = useRef<Optional<HTMLCanvasElement>>(null);
   const contextRef = useRef<Optional<CanvasRenderingContext2D>>(null);
@@ -431,7 +431,7 @@ export default function PinchableDart({
 
       const currentScale =
         scale *
-        (1 + (0.5 * (currentDistance - initialDistance)) / initialDistance);
+        (1 + (0.05 * (currentDistance - initialDistance)) / initialDistance);
 
       if (currentScale < minScale) {
         setScale(minScale);


### PR DESCRIPTION
## Summary by Sourcery

Fix mobile touch and pinch gesture issues by accurately tracking press and move states, adjusting scale sensitivity, and enabling tap-to-add-point functionality.

New Features:
- Register a tap on the canvas as a new point when a touch doesn’t move within the long-press timeframe.

Bug Fixes:
- Prevent touch move handling unless a press state is active to avoid unintended drags.
- Reduce pinch scale sensitivity by adjusting the scale change factor.
- Ensure press, movement, and pinch states are reset correctly on touch end and cancel.

Enhancements:
- Lower the default maxOffset from 400 to 40 for tighter drag limits.