### PR TITLE
:iphone: fix(mobile): meta tag cannot take effect so use CSS again

### DIFF
--- a/ExtremeMemory/index.html
+++ b/ExtremeMemory/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>

--- a/ExtremeMemory/src/App.css
+++ b/ExtremeMemory/src/App.css
@@ -4,4 +4,9 @@
   justify-content: center;
   align-items: center;
   margin: auto 0;
+  touch-action: none;
+}
+
+canvas#pinchable-dart {
+  touch-action: auto !important;
 }

--- a/ExtremeMemory/src/components/pinchable-dart.tsx
+++ b/ExtremeMemory/src/components/pinchable-dart.tsx
@@ -668,6 +668,7 @@ export default function PinchableDart({
   return (
     <div style={{ display: "flex", flexDirection: "column" }}>
       <canvas
+        id="pinchable-dart"
         ref={canvasRef}
         style={{ width: "100%" }}
         onTouchStart={handleTouchStart}


### PR DESCRIPTION
## Summary by Sourcery

Fix mobile pinch zoom by updating the HTML meta tags and applying touch-action CSS rules to selectively re-enable touch interactions on the dart canvas.

Bug Fixes:
- Separate the viewport meta tag from the charset tag and remove maximum-scale and user-scalable restrictions to restore pinch zoom
- Apply global touch-action:none in CSS and override it to auto on the dart canvas to control touch behaviors

Enhancements:
- Add id="pinchable-dart" to the canvas element for targeted CSS rules