### PR TITLE
:bug: fix(mobile): fix the out-of-bound index in `handleTouchEnd`

### DIFF
--- a/ExtremeMemory/src/components/pinchable-dart.tsx
+++ b/ExtremeMemory/src/components/pinchable-dart.tsx
@@ -527,7 +527,7 @@ export default function PinchableDart({
 
       const rect = canvas.getBoundingClientRect();
       const clickAbsoluteX = e.touches[0].clientX - rect.left;
-      const clickAbsoluteY = e.touches[1].clientY - rect.top;
+      const clickAbsoluteY = e.touches[0].clientY - rect.top;
 
       setPoints([
         ...points,
@@ -678,7 +678,10 @@ export default function PinchableDart({
         )}
         onTouchEnd={handleTouchEnd}
         onMouseDown={handleMouseDown}
-        onMouseMove={handleMouseMove}
+        onMouseMove={throttle(
+          (e: React.MouseEvent<HTMLCanvasElement>) => handleMouseMove(e),
+          25,
+        )}
         onMouseUp={handleMouseUp}
       />
       <input


### PR DESCRIPTION
## Summary by Sourcery

Fix an out-of-bound touch index bug in handleTouchEnd and improve mouse-move performance by throttling events.

Bug Fixes:
- Correct the Y-coordinate calculation in handleTouchEnd to use the first touch point instead of a nonexistent second touch.

Enhancements:
- Throttle the onMouseMove handler to fire at most once every 25ms to reduce event flooding.