### PR TITLE
:bug: fix(components): fix the width / height reference

### DIFF
--- a/ExtremeMemory/src/App.tsx
+++ b/ExtremeMemory/src/App.tsx
@@ -1,9 +1,42 @@
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import "./App.css";
 import PinchableDart, { type Optional } from "./components/pinchable-dart";
 
 function App() {
   const containerRef = useRef<Optional<HTMLDivElement>>(null);
+  /* pettier-ignore */
+  const [dimensions, setDimensions] = useState<
+    Optional<{
+      width: number;
+      height: number;
+    }>
+  >(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const updateDimensions = () => {
+      if (containerRef.current) {
+        setDimensions({
+          width: containerRef.current.clientWidth,
+          height: containerRef.current.clientHeight,
+        });
+      }
+    };
+
+    updateDimensions();
+
+    window.addEventListener("resize", updateDimensions);
+
+    const resizeObserver = new ResizeObserver(updateDimensions);
+    resizeObserver.observe(containerRef.current);
+
+    return () => {
+      window.removeEventListener("resize", updateDimensions);
+      resizeObserver.disconnect();
+    };
+  }, []);
+
   return (
     <div
       style={{
@@ -15,8 +48,8 @@ function App() {
       ref={containerRef}
     >
       <PinchableDart
-        width={containerRef.current?.clientWidth}
-        height={containerRef.current?.clientHeight}
+        width={dimensions?.width}
+        height={dimensions?.width}
       />
     </div>
   );

--- a/ExtremeMemory/src/components/pinchable-dart.tsx
+++ b/ExtremeMemory/src/components/pinchable-dart.tsx
@@ -95,7 +95,7 @@ export default function PinchableDart({
   pointRadius = 5,
   minScale = 0.5,
   maxScale = 5,
-  maxOffset = 40,
+  maxOffset = 400,
 }: PinchableDartProps) {
   const canvasRef = useRef<Optional<HTMLCanvasElement>>(null);
   const contextRef = useRef<Optional<CanvasRenderingContext2D>>(null);
@@ -175,6 +175,11 @@ export default function PinchableDart({
    * This function draws the dart and the points.
    */
   const drawDart = () => {
+    if (canvasRef.current) {
+      canvasRef.current.width = width;
+      canvasRef.current.height = height;
+      setCenter({ x: width / 2, y: height / 2 });
+    }
     const drawContext = contextRef.current;
     if (drawContext === null) return;
 
@@ -669,7 +674,10 @@ export default function PinchableDart({
     };
   }, []);
 
-  useEffect(() => drawDart(), [points, scale, draggingPoint]);
+  useEffect(
+    () => drawDart(),
+    [points, scale, draggingPoint, width, length, center],
+  );
 
   return (
     <div style={{ display: "flex", flexDirection: "column" }}>


### PR DESCRIPTION
## Summary by Sourcery

Introduce responsive container dimension tracking in App using state and ResizeObserver, pass consistent width and height props to PinchableDart, and update PinchableDart to resize its canvas, adjust its center, and redraw when size or related props change

Bug Fixes:
- Correct height reference when passing dimensions to PinchableDart component

Enhancements:
- Add state and ResizeObserver in App to track and update container dimensions on window resize
- Pass dynamic width and height state values to PinchableDart instead of direct DOM queries
- Update drawDart to set canvas width/height and recalculate center before drawing
- Include width, length, and center in PinchableDart's effect dependencies for proper redraw

Chores:
- Increase default maxOffset from 40 to 400 for broader drag range