### PR TITLE
:bug: fix(components): fix the width / height reference, until width and height has been updated

### DIFF
--- a/ExtremeMemory/src/App.tsx
+++ b/ExtremeMemory/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import "./App.css";
 import PinchableDart, { type Optional } from "./components/pinchable-dart";
 
@@ -47,10 +47,11 @@ function App() {
       }}
       ref={containerRef}
     >
-      <PinchableDart
-        width={dimensions?.width}
-        height={dimensions?.width}
-      />
+      {dimensions !== null ? (
+        <PinchableDart width={dimensions.width} height={dimensions.width} />
+      ) : (
+        <React.Fragment />
+      )}
     </div>
   );
 }

--- a/ExtremeMemory/src/components/pinchable-dart.tsx
+++ b/ExtremeMemory/src/components/pinchable-dart.tsx
@@ -25,9 +25,9 @@ interface Point {
 
 interface PinchableDartProps {
   /** The width of PinchableDart, default to 800 */
-  width?: number;
+  width: number;
   /** The height of PinchableDart, default to 800 */
-  height?: number;
+  height: number;
   /** The color of ring 1~3, default to #ffff00 */
   color1?: `#${string}`;
   /** The color of ring 4~5, default to #ff0000 */
@@ -78,8 +78,8 @@ function throttle(callbackFn: Function, delay: number) {
 }
 
 export default function PinchableDart({
-  width = 800,
-  height = 800,
+  width,
+  height,
   color1 = "#ffff00",
   color2 = "#ff0000",
   color3 = "#0000ff",
@@ -178,7 +178,9 @@ export default function PinchableDart({
     if (canvasRef.current) {
       canvasRef.current.width = width;
       canvasRef.current.height = height;
-      setCenter({ x: width / 2, y: height / 2 });
+      if (width / 2 !== center.x && height / 2 !== center.y) {
+        setCenter({ x: width / 2, y: height / 2 });
+      }
     }
     const drawContext = contextRef.current;
     if (drawContext === null) return;
@@ -674,10 +676,7 @@ export default function PinchableDart({
     };
   }, []);
 
-  useEffect(
-    () => drawDart(),
-    [points, scale, draggingPoint, width, length, center],
-  );
+  useEffect(() => drawDart(), [points, scale, draggingPoint]);
 
   return (
     <div style={{ display: "flex", flexDirection: "column" }}>


### PR DESCRIPTION
## Summary by Sourcery

Enforce explicit sizing for PinchableDart, ensure it only renders with valid dimensions, and optimize state and effect updates to reduce redundant renders

Bug Fixes:
- Guard against null dimensions in App.tsx by conditionally rendering PinchableDart only when dimensions are defined
- Only update center state when new center values differ to prevent unnecessary re-renders

Enhancements:
- Require explicit width and height props in PinchableDart instead of relying on default values
- Trim drawDart effect dependencies to points, scale, and draggingPoint to avoid redundant redraws